### PR TITLE
Remove supported ciphers restriction

### DIFF
--- a/src/Gateways/Gateway.php
+++ b/src/Gateways/Gateway.php
@@ -84,25 +84,7 @@ abstract class Gateway
             curl_setopt($request, CURLOPT_HTTPHEADER, $headers);
             curl_setopt($request, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
             // curl_setopt($request, CURLOPT_VERBOSE, true);
-            //For TLS 1.2
-            $supportedCiphers = [
-                'ECDHE-ECDSA-AES256-GCM-SHA384',
-                'ECDHE-RSA-AES256-GCM-SHA384',
-                'ECDHE-ECDSA-AES256-SHA384',
-                'ECDHE-RSA-AES256-SHA384',
-                'ECDHE-ECDSA-CHACHA20-POLY1305',
-                'ECDHE-RSA-CHACHA20-POLY1305',
-                'DHE-RSA-AES256-GCM-SHA384',
-                'DHE-RSA-AES256-SHA256',
-                'ECDHE-ECDSA-AES128-GCM-SHA256',
-                'ECDHE-RSA-AES128-GCM-SHA256',
-                'ECDHE-ECDSA-AES128-SHA256',
-                'ECDHE-RSA-AES128-SHA256',
-                'DHE-RSA-AES128-GCM-SHA256',
-                'DHE-RSA-AES128-SHA256'
-            ];
             curl_setopt($request, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
-            curl_setopt($request, CURLOPT_SSL_CIPHER_LIST, implode(':', $supportedCiphers));
 
             $curlResponse = curl_exec($request);
             $curlInfo = curl_getinfo($request);


### PR DESCRIPTION
As per:
https://curl.haxx.se/docs/ssl-ciphers.html
cipher list specifications depend on the underlying SSL library used.
The specification pre this commit could not work with a curl library compiled against the NSS SSL library.

Specifying a cipher list is fragile and 
curl_setopt($request, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
along with an appropriate server configuration should provide the required levels of security without them