### PR TITLE
Remove unsecure CURLOPT_SSL_VERIFY* options

### DIFF
--- a/src/Gateways/Gateway.php
+++ b/src/Gateways/Gateway.php
@@ -77,8 +77,6 @@ abstract class Gateway
             curl_setopt($request, CURLOPT_CONNECTTIMEOUT, $this->timeout);
             curl_setopt($request, CURLOPT_TIMEOUT, $this->timeout);
             curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false); //true,);
-            curl_setopt($request, CURLOPT_SSL_VERIFYHOST, false); //2,);
             curl_setopt($request, CURLOPT_CUSTOMREQUEST, strtoupper($verb));
             curl_setopt($request, CURLOPT_POSTFIELDS, $data);
             curl_setopt($request, CURLOPT_HTTPHEADER, $headers);


### PR DESCRIPTION
Verification of peer certificate against trusted CAs and hostname verification should never be turned off otherwise MITM attacks are possible.