### PR TITLE
Allow communication request and/or response tracing

### DIFF
--- a/src/Gateways/Gateway.php
+++ b/src/Gateways/Gateway.php
@@ -28,6 +28,16 @@ abstract class Gateway
      * @var array<integer,string>
      */
     public $curlOptions;
+    
+    /**
+     * @var ICommsTracer|null
+     */
+    public $requestTracer;
+
+    /**
+     * @var IcommsTracer|null
+     */
+    public $responseTracer;
 
     /**
      * @param string $contentType
@@ -105,6 +115,14 @@ abstract class Gateway
             $response = new GatewayResponse();
             $response->statusCode = $curlInfo['http_code'];
             $response->rawResponse = $curlResponse;
+
+            if ($this->requestTracer instanceof ICommsTracer){
+                $this->requestTracer->captureTrace($data);
+            }
+            if ($this->responseTracer instanceof ICommsTracer){
+                $this->responseTracer->captureTrace($curlResponse);
+            }
+
             return $response;
         } catch (\Exception $e) {
             throw new \Exception(

--- a/src/Gateways/ICommTracer.php
+++ b/src/Gateways/ICommTracer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GlobalPayments\Api\Gateways;
+
+/**
+ * Allows clients to implement an object capable of capturing raw API messages for
+ * tracing/auditing purposes
+ *
+ * NOTE: clients are responsible for ensuring captured messages are handled securely, including
+ * ensuring that raw cardholder data and other sensitive data is appropriately redacted
+ */
+interface ICommsTracer
+{
+    /**
+     * @var string $string
+     */
+    public function captureTrace($string);
+}

--- a/src/ServicesConfig.php
+++ b/src/ServicesConfig.php
@@ -29,6 +29,16 @@ class ServicesConfig
     public $curlOptions;
     public $serviceUrl;
     public $timeout;
+    
+    /**
+     * @var ICommsTracer|null
+     */
+    public $requestTracer;
+
+    /**
+     * @var ICommsTracer|null
+     */
+    public $responseTracer;
 
     public function __construct()
     {

--- a/src/ServicesContainer.php
+++ b/src/ServicesContainer.php
@@ -20,9 +20,8 @@ class ServicesContainer
     /**
      * ServicesContainer constructor.
      *
-     * @param IGateway $gateway
-     *
-     * @return
+     * @param IPaymentGateway $gateway
+     * @param IRecurringService|null $recurring
      */
     public function __construct(IPaymentGateway $gateway, IRecurringService $recurring = null)
     {
@@ -67,6 +66,8 @@ class ServicesContainer
             $gateway->serviceUrl = $config->serviceUrl;
             $gateway->hostedPaymentConfig = $config->hostedPaymentConfig;
             $gateway->curlOptions = $config->curlOptions;
+            $gateway->requestTracer = $config->requestTracer;
+            $gateway->responseTracer = $config->responseTracer;
             static::$instance = new static($gateway, $gateway);
         } else {
             $gateway = new PorticoConnector();
@@ -81,6 +82,8 @@ class ServicesContainer
             $gateway->timeout = $config->timeout;
             $gateway->serviceUrl = $config->serviceUrl . '/Hps.Exchange.PosGateway/PosGatewayService.asmx';
             $gateway->curlOptions = $config->curlOptions;
+            $gateway->requestTracer = $config->requestTracer;
+            $gateway->responseTracer = $config->responseTracer;
 
             $payplanEndPoint = (strpos(strtolower($config->serviceUrl), 'cert.') > 0) ?
                                 '/Portico.PayPlan.v2/':
@@ -98,6 +101,8 @@ class ServicesContainer
             $recurring->timeout = $config->timeout;
             $recurring->serviceUrl = $config->serviceUrl . $payplanEndPoint;
             $recurring->curlOptions = $config->curlOptions;
+            $recurring->requestTracer = $config->requestTracer;
+            $recurring->responseTracer = $config->responseTracer;
 
             static::$instance = new static($gateway, $recurring);
         }


### PR DESCRIPTION
An interface SDK clients can implement to capture comms requests/responses.
Changes to config and container to optionally carry such classes through to communications class.
