### PR TITLE
Fix 3DSv2 exception on PHP7.1+

### DIFF
--- a/src/Gateways/RestGateway.php
+++ b/src/Gateways/RestGateway.php
@@ -32,13 +32,18 @@ abstract class RestGateway extends Gateway
         if (!in_array($response->statusCode, [200, 204])) {
             $parsed = json_decode($response->rawResponse);
             $error = isset($parsed->error) ? $parsed->error : $parsed;
-            throw new GatewayException(
-                sprintf(
-                    'Status Code: %s - %s',
-                    $response->statusCode,
-                    isset($error->error_description) ? $error->error_description : (isset($error->message) ? $error->message : (string) $error)
-                )
+            $message = sprintf(
+                'Status Code: %s - %s',
+                $response->statusCode,
+                isset($error->error_description) ? $error->error_description : (isset($error->message) ? $error->message : (string) $error)
             );
+
+            if (!empty($error->error_detail)) {
+                $message .= " ({$error->error_detail})";
+            }
+
+            // Ex: "Status Code: 400 - Required Data Element (number)"
+            throw new GatewayException($message);
         }
 
         return $response->rawResponse;

--- a/src/ServicesContainer.php
+++ b/src/ServicesContainer.php
@@ -53,7 +53,7 @@ class ServicesContainer
      *
      * @return
      */
-    public function __construct(IPaymentGateway $gateway, IRecurringService $recurring = null)
+    public function __construct(IPaymentGateway $gateway = null, IRecurringService $recurring = null)
     {
         $this->gateway = $gateway;
         $this->recurring = $recurring;


### PR DESCRIPTION
The `$gateway` argument in the ServiceContainer needs to be nullable because when we use it in the Secure3DBuilder, we don't pass in a gateway (https://github.com/globalpayments/php-sdk/blob/master/src/Builders/Secure3dBuilder.php#L1122) which causes a fatal error in PHP 7.1 and above (see the first sub-heading from this page https://www.php.net/manual/en/migration71.incompatible.php)

Also, I've updated the RestGateway exception to include the `error_detail` key from the API response in the exception message because there was no way to know why an error was occurring without digging into the raw request