### PR TITLE
Enable updating expiry for stored cards without specifying the card number

### DIFF
--- a/src/Gateways/RealexConnector.php
+++ b/src/Gateways/RealexConnector.php
@@ -919,7 +919,9 @@ class RealexConnector extends XmlGateway implements IPaymentGateway, IRecurringS
         $cardElement = $xml->createElement("card");
         $cardElement->appendChild($xml->createElement("ref", $paymentKey));
         $cardElement->appendChild($xml->createElement("payerref", $payment->customerKey));
-        $cardElement->appendChild($xml->createElement("number", $card->number));
+        if (!empty($card->number)) {
+            $cardElement->appendChild($xml->createElement('number', $card->number));
+        }
         $cardElement->appendChild($xml->createElement("expdate", $card->getShortExpiry()));
         $cardElement->appendChild($xml->createElement("chname", $card->cardHolderName));
         $cardElement->appendChild($xml->createElement("type", strtoupper($card->getCardType())));

--- a/src/PaymentMethods/CreditCardData.php
+++ b/src/PaymentMethods/CreditCardData.php
@@ -71,6 +71,13 @@ class CreditCardData extends Credit implements ICardData
     public $readerPresent;
 
     /**
+     * Card type
+     *
+     * @var string
+     */
+    public $cardType;
+
+    /**
      * Card type regex patterns
      *
      * @var array
@@ -124,6 +131,10 @@ class CreditCardData extends Credit implements ICardData
             '',
             $this->number
         );
+
+        if (!empty($this->cardType)) {
+            return $this->cardType;
+        }
 
         foreach (static::$cardTypes as $type => $regex) {
             if (1 === preg_match($regex, $this->number)) {


### PR DESCRIPTION
- Card number is added to payload only if set
- Card type can be overridden to support scenario where number is not specified and type cannot be auto detected