### PR TITLE
Added currency to Transaction refund method

### DIFF
--- a/src/Entities/Transaction.php
+++ b/src/Entities/Transaction.php
@@ -319,13 +319,15 @@ class Transaction
      * Refunds/returns the original transaction.
      *
      * @param string|float $amount The amount to refund/return
+     * @param string $currency The currency type for this refund/return
      *
      * @return ManagementBuilder
      */
-    public function refund($amount = null)
+    public function refund($amount = null, $currency = null)
     {
         return (new ManagementBuilder(TransactionType::REFUND))
             ->withPaymentMethod($this->transactionReference)
+            ->withCurrency($currency)
             ->withAmount($amount);
     }
 


### PR DESCRIPTION
1. Added $currency param to method
2. Added withCurrency to the builder

Prior to this change was receiving error 'currency cannot be null for this transaction type' (heartland/portico).