### PR TITLE
Fix php compatibility to php5.6 [WIP]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">= 5.5.9",
+    "php": ">= 5.6",
     "ext-curl": "*",
     "ext-dom": "*",
     "ext-openssl": "*"
@@ -20,7 +20,8 @@
     "phpunit/phpunit": "~5.0",
     "brianium/paratest": "dev-master",
     "squizlabs/php_codesniffer": "2.*",
-    "phpstan/phpstan-shim": "^0.8.4"
+    "phpstan/phpstan-shim": "^0.8.4",
+    "phpcompatibility/php-compatibility": "^9.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5400d26ad80e42feba9aa303ed2a3d0c",
+    "content-hash": "99308aae38a7661eac02df6534cf835f",
     "packages": [],
     "packages-dev": [
         {
@@ -53,12 +53,12 @@
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/brianium/paratest.git",
+                "url": "https://github.com/paratestphp/paratest.git",
                 "reference": "b4c5be606a03af51c313c12018a5e80d0ab9b94b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brianium/paratest/zipball/b4c5be606a03af51c313c12018a5e80d0ab9b94b",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/b4c5be606a03af51c313c12018a5e80d0ab9b94b",
                 "reference": "b4c5be606a03af51c313c12018a5e80d0ab9b94b",
                 "shasum": ""
             },
@@ -316,6 +316,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
@@ -1143,6 +1144,64 @@
             "time": "2015-05-17T12:39:23+00:00"
         },
         {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
             "name": "phpdocumentor/fileset",
             "version": "1.0.0",
             "source": {
@@ -1231,12 +1290,12 @@
             "version": "v2.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/phpDocumentor2.git",
+                "url": "https://github.com/phpDocumentor/phpDocumentor.git",
                 "reference": "be607da0eef9b9249c43c5b4820d25d631c73667"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/phpDocumentor2/zipball/be607da0eef9b9249c43c5b4820d25d631c73667",
+                "url": "https://api.github.com/repos/phpDocumentor/phpDocumentor/zipball/be607da0eef9b9249c43c5b4820d25d631c73667",
                 "reference": "be607da0eef9b9249c43c5b4820d25d631c73667",
                 "shasum": ""
             },
@@ -1565,6 +1624,7 @@
                 "MIT"
             ],
             "description": "PHPStan Phar distribution",
+            "abandoned": "phpstan/phpstan",
             "time": "2017-08-25T08:33:08+00:00"
         },
         {
@@ -1955,6 +2015,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2016-12-08T20:27:08+00:00"
         },
         {
@@ -3552,6 +3613,7 @@
                 "cache",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-cache",
             "time": "2016-12-16T11:35:47+00:00"
         },
         {
@@ -3608,6 +3670,7 @@
                 "config",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-config",
             "time": "2016-02-04T23:01:10+00:00"
         },
         {
@@ -3662,6 +3725,7 @@
                 "events",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-eventmanager",
             "time": "2016-12-19T21:47:12+00:00"
         },
         {
@@ -3722,6 +3786,7 @@
                 "filter",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-filter",
             "time": "2017-05-17T20:56:17+00:00"
         },
         {
@@ -3780,6 +3845,7 @@
                 "hydrator",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-hydrator",
             "time": "2016-02-18T22:38:26+00:00"
         },
         {
@@ -3847,6 +3913,7 @@
                 "i18n",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-i18n",
             "time": "2017-05-17T17:00:12+00:00"
         },
         {
@@ -3897,6 +3964,7 @@
                 "json",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-json",
             "time": "2016-04-01T02:34:00+00:00"
         },
         {
@@ -3954,6 +4022,7 @@
                 "serializer",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-serializer",
             "time": "2016-06-21T17:01:55+00:00"
         },
         {
@@ -4006,6 +4075,7 @@
                 "servicemanager",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-servicemanager",
             "time": "2016-12-19T19:14:29+00:00"
         },
         {
@@ -4065,6 +4135,7 @@
                 "stdlib",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-stdlib",
             "time": "2016-04-12T21:17:31+00:00"
         },
         {
@@ -4190,7 +4261,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 5.5.9",
+        "php": ">= 5.6",
         "ext-curl": "*",
         "ext-dom": "*",
         "ext-openssl": "*"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,4 +2,8 @@
 <ruleset name="Heartland">
     <file>./src</file>
     <rule ref="PSR2"/>
+
+    <rule ref="PHPCompatibility">
+        <config name="testVersion" value="5.6-"/>
+    </rule>
 </ruleset>

--- a/src/Builders/Secure3dBuilder.php
+++ b/src/Builders/Secure3dBuilder.php
@@ -640,7 +640,7 @@ class Secure3dBuilder extends BaseBuilder
     }
 
     /** @return Secure3dBuilder */
-    public function withAddressMatchIndicator(bool $value)
+    public function withAddressMatchIndicator($value)
     {
         $this->addressMatchIndicator = $value;
         return $this;
@@ -955,7 +955,7 @@ class Secure3dBuilder extends BaseBuilder
     }
 
     /** @return Secure3dBuilder */
-    public function withPreviousSuspiciousActivity(bool $previousSuspiciousActivity)
+    public function withPreviousSuspiciousActivity($previousSuspiciousActivity)
     {
         $this->previousSuspiciousActivity = $previousSuspiciousActivity;
         return $this;

--- a/src/Builders/TransactionReportBuilder.php
+++ b/src/Builders/TransactionReportBuilder.php
@@ -134,7 +134,7 @@ class TransactionReportBuilder extends ReportBuilder
      */
     public function where($criteria, $value)
     {
-        return $this->searchBuilder->and($criteria, $value);
+        return $this->searchBuilder->add($criteria, $value);
     }
         
     protected function setupValidations()

--- a/src/Entities/Reporting/SearchCriteriaBuilder.php
+++ b/src/Entities/Reporting/SearchCriteriaBuilder.php
@@ -211,8 +211,30 @@ class SearchCriteriaBuilder
     {
         $this->reportBuilder = $reportBuilder;
     }
-    
-    public function and($criteria, $value)
+
+    /**
+     * Added for php5.6 compatibility
+     * @param $name
+     * @param $arguments
+     * @return mixed
+     */
+    public function __call($name, $arguments)
+    {
+        $methods = [
+            'and' => 'add'
+        ];
+        if(isset($methods[$name])) {
+            return call_user_func_array(array($this, $methods[$name]), $arguments);
+        }
+    }
+
+    /**
+     * Added for php5.6 compatibility
+     * @param $criteria
+     * @param $value
+     * @return $this
+     */
+    public function add($criteria, $value)
     {
         if (property_exists($this, $criteria)) {
             $this->{$criteria} = $value;

--- a/src/Gateways/Gp3DSProvider.php
+++ b/src/Gateways/Gp3DSProvider.php
@@ -179,7 +179,7 @@ class Gp3DSProvider extends RestGateway implements ISecure3dProvider
             $request['order'] = $this->maybeSetKey($request['order'], 'currency', $builder->getCurrency());
             $request['order'] = $this->maybeSetKey($request['order'], 'id', $orderId);
             $request['order'] = $this->maybeSetKey($request['order'], 'address_match_indicator', ($builder->isAddressMatchIndicator() ? true : false));
-            $request['order'] = $this->maybeSetKey($request['order'], 'date_time_created', (new \DateTime($builder->getOrderCreateDate()))->format(\DateTime::RFC3339_EXTENDED));
+            $request['order'] = $this->maybeSetKey($request['order'], 'date_time_created', (new \DateTime($builder->getOrderCreateDate()))->format('Y-m-d\TH:i:s.vP'));
             $request['order'] = $this->maybeSetKey($request['order'], 'gift_card_count', $builder->getGiftCardCount());
             $request['order'] = $this->maybeSetKey($request['order'], 'gift_card_currency', $builder->getGiftCardCurrency());
             $request['order'] = $this->maybeSetKey($request['order'], 'gift_card_amount', preg_replace('/[^0-9]/', '', sprintf('%01.2f', $builder->getGiftCardAmount())));

--- a/src/Gateways/Gp3DSProvider.php
+++ b/src/Gateways/Gp3DSProvider.php
@@ -179,7 +179,7 @@ class Gp3DSProvider extends RestGateway implements ISecure3dProvider
             $request['order'] = $this->maybeSetKey($request['order'], 'currency', $builder->getCurrency());
             $request['order'] = $this->maybeSetKey($request['order'], 'id', $orderId);
             $request['order'] = $this->maybeSetKey($request['order'], 'address_match_indicator', ($builder->isAddressMatchIndicator() ? true : false));
-            $request['order'] = $this->maybeSetKey($request['order'], 'date_time_created', (new \DateTime($builder->getOrderCreateDate()))->format('Y-m-d\TH:i:s.vP'));
+            $request['order'] = $this->maybeSetKey($request['order'], 'date_time_created', (new \DateTime($builder->getOrderCreateDate()))->format('Y-m-d\TH:i:s\z'));
             $request['order'] = $this->maybeSetKey($request['order'], 'gift_card_count', $builder->getGiftCardCount());
             $request['order'] = $this->maybeSetKey($request['order'], 'gift_card_currency', $builder->getGiftCardCurrency());
             $request['order'] = $this->maybeSetKey($request['order'], 'gift_card_amount', preg_replace('/[^0-9]/', '', sprintf('%01.2f', $builder->getGiftCardAmount())));

--- a/src/Gateways/Gp3DSProvider.php
+++ b/src/Gateways/Gp3DSProvider.php
@@ -207,7 +207,7 @@ class Gp3DSProvider extends RestGateway implements ISecure3dProvider
 
             // payer
             $request['payer'] = [];
-            $request['payer'] = $this->maybeSetKey($request['payer'], 'email', $builder->getCustomerEmail() ?? null);
+            $request['payer'] = $this->maybeSetKey($request['payer'], 'email', $builder->getCustomerEmail() ? $builder->getCustomerEmail() : null);
             $request['payer'] = $this->maybeSetKey($request['payer'], 'id', $builder->getCustomerAccountId());
             $request['payer'] = $this->maybeSetKey($request['payer'], 'account_age', $builder->getAccountAgeIndicator());
             $request['payer'] = $this->maybeSetKey($request['payer'], 'account_creation_date', null !== $builder->getAccountCreateDate() ? date('Y-m-d', strtotime($builder->getAccountCreateDate())) : null);
@@ -339,23 +339,24 @@ class Gp3DSProvider extends RestGateway implements ISecure3dProvider
         $secureEcom = new ThreeDSecure();
 
         // check enrolled
-        $secureEcom->serverTransactionId = $doc['server_trans_id'] ?? null;
+        $secureEcom->serverTransactionId = isset($doc['server_trans_id']) ? $doc['server_trans_id'] : null;
         if (array_key_exists('enrolled', $doc)) {
             $secureEcom->enrolled = (bool)$doc['enrolled'];
         }
-        $secureEcom->issuerAcsUrl = ($doc['method_url'] ?? null) . ($doc['challenge_request_url'] ?? null);
+        $secureEcom->issuerAcsUrl = (isset($doc['method_url']) ? $doc['method_url'] : null)
+            . (isset($doc['challenge_request_url']) ? $doc['challenge_request_url'] : null);
 
         // get authentication data
-        $secureEcom->acsTransactionId = $doc['acs_trans_id'] ?? null;
-        $secureEcom->directoryServerTransactionId = $doc['ds_trans_id'] ?? null;
-        $secureEcom->authenticationType = $doc['authentication_type'] ?? null;
-        $secureEcom->authenticationValue = $doc['authentication_value'] ?? null;
-        $secureEcom->eci = $doc['eci'] ?? null;
-        $secureEcom->status = $doc['status'] ?? null;
-        $secureEcom->statusReason = $doc['status_reason'] ?? null;
-        $secureEcom->authenticationSource = $doc['authentication_source'] ?? null;
-        $secureEcom->messageCategory = $doc['message_category'] ?? null;
-        $secureEcom->messageVersion = $doc['message_version'] ?? null;
+        $secureEcom->acsTransactionId = isset($doc['acs_trans_id']) ? $doc['acs_trans_id'] : null;
+        $secureEcom->directoryServerTransactionId = isset($doc['ds_trans_id']) ? $doc['ds_trans_id'] : null;
+        $secureEcom->authenticationType = isset($doc['authentication_type']) ? $doc['authentication_type'] : null;
+        $secureEcom->authenticationValue = isset($doc['authentication_value']) ? $doc['authentication_value'] : null;
+        $secureEcom->eci = isset($doc['eci']) ? $doc['eci'] : null;
+        $secureEcom->status = isset($doc['status']) ? $doc['status'] : null;
+        $secureEcom->statusReason = isset($doc['status_reason']) ? $doc['status_reason'] : null;
+        $secureEcom->authenticationSource = isset($doc['authentication_source']) ? $doc['authentication_source'] : null;
+        $secureEcom->messageCategory = isset($doc['message_category']) ? $doc['message_category'] : null;
+        $secureEcom->messageVersion = isset($doc['message_version']) ? $doc['message_version'] : null;
 
         // challenge mandated
         if (array_key_exists('challenge_mandated', $doc)) {
@@ -363,34 +364,52 @@ class Gp3DSProvider extends RestGateway implements ISecure3dProvider
         }
 
         // initiate authentication
-        $secureEcom->cardHolderResponseInfo = $doc['cardHolder_response_info'] ?? null;
+        $secureEcom->cardHolderResponseInfo = isset($doc['cardHolder_response_info']) ? $doc['cardHolder_response_info'] : null;
 
         // device_render_options
         if (array_key_exists('device_render_options', $doc)) {
             $renderOptions = $doc['device_render_options'];
-            $secureEcom->sdkInterface = $renderOptions['sdk_interface'] ?? null;
-            $secureEcom->sdkUiType = $renderOptions['sdk_ui_type'] ?? null;
+            $secureEcom->sdkInterface = isset($renderOptions['sdk_interface']) ? $renderOptions['sdk_interface'] : null;
+            $secureEcom->sdkUiType = isset($renderOptions['sdk_ui_type']) ? $renderOptions['sdk_ui_type'] : null;
         }
 
         // message_extension
         if (array_key_exists('message_extension', $doc)) {
-            $secureEcom->criticalityIndicator = $doc['message_extension']['criticality_indicator'] ?? null;
-            $secureEcom->messageExtensionId = $doc['message_extension']['id'] ?? null;
-            $secureEcom->messageExtensionName = $doc['message_extension']['name'] ?? null;
+            $secureEcom->criticalityIndicator = isset($doc['message_extension']['criticality_indicator'])
+                ? $doc['message_extension']['criticality_indicator']
+                : null;
+            $secureEcom->messageExtensionId = isset($doc['message_extension']['id'])
+                ? $doc['message_extension']['id']
+                : null;
+            $secureEcom->messageExtensionName = isset($doc['message_extension']['name'])
+                ? $doc['message_extension']['name']
+                : null;
         }
 
         // versions
-        $secureEcom->directoryServerEndVersion = $doc['ds_protocol_version_end'] ?? null;
-        $secureEcom->directoryServerStartVersion = $doc['ds_protocol_version_start'] ?? null;
-        $secureEcom->acsEndVersion = $doc['acs_protocol_version_end'] ?? null;
-        $secureEcom->acsStartVersion = $doc['acs_protocol_version_start'] ?? null;
+        $secureEcom->directoryServerEndVersion = isset($doc['ds_protocol_version_end'])
+            ? $doc['ds_protocol_version_end']
+            : null;
+        $secureEcom->directoryServerStartVersion = isset($doc['ds_protocol_version_start'])
+            ? $doc['ds_protocol_version_start']
+            : null;
+        $secureEcom->acsEndVersion = isset($doc['acs_protocol_version_end'])
+            ? $doc['acs_protocol_version_end']
+            : null;
+        $secureEcom->acsStartVersion = isset($doc['acs_protocol_version_start'])
+            ? $doc['acs_protocol_version_start']
+            : null;
 
         // payer authentication request
         if (array_key_exists('method_data', $doc)) {
             $methodData = $doc['method_data'];
-            $secureEcom->payerAuthenticationRequest = $methodData['encoded_method_data'] ?? null;
+            $secureEcom->payerAuthenticationRequest = isset($methodData['encoded_method_data'])
+                ? $methodData['encoded_method_data']
+                : null;
         } elseif (array_key_exists('encoded_creq', $doc)) {
-            $secureEcom->payerAuthenticationRequest = $doc['encoded_creq'] ?? null;
+            $secureEcom->payerAuthenticationRequest = isset($doc['encoded_creq'])
+                ? $doc['encoded_creq']
+                : null;
         }
 
         $response = new Transaction();


### PR DESCRIPTION
## Issue
After run `./vendor/bin/phpcs -p src --standard=PHPCompatibility --runtime-set testVersion 5.6- --report=source` I got next errors
```
PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
----------------------------------------------------------------------
STANDARD  CATEGORY            SNIFF                              COUNT
----------------------------------------------------------------------
PHPCompa  Operators           New operators t_coalesce found     26
PHPCompa  Function declar  New param type declarations bool   2
PHPCompa  Keywords            Forbidden names and found          1
----------------------------------------------------------------------
A TOTAL OF 29 SNIFF VIOLATIONS WERE FOUND IN 3 SOURCES
----------------------------------------------------------------------

Time: 45.79 secs; Memory: 26Mb

```
## Changelog
- Raised mandatory php version in composer.json to 5.6
- Added `phpcompatibility/php-compatibility` for check code compatibility
- Added `PHPCompatibility` rule to ` phpcs.xml `
- Fixed all compatibility issues
