### PR TITLE
RealexConnector unit tests fixes for testverifyenrolled024b

### DIFF
--- a/test/Integration/Gateways/RealexConnector/Certifications/SdkTest.php
+++ b/test/Integration/Gateways/RealexConnector/Certifications/SdkTest.php
@@ -823,7 +823,7 @@ class RealexSdkCertification extends TestCase
     public function testAuth014b()
     {
         $this->markTestSkipped('Exception not thrown');
-        
+
         $config = $this->getBaseConfig();
         ServicesContainer::configureService($config);
 
@@ -946,7 +946,7 @@ class RealexSdkCertification extends TestCase
     public function testAuth015d()
     {
         $this->markTestSkipped('Exception not thrown');
-        
+
         $config = $this->getBaseConfig();
         ServicesContainer::configureService($config);
 
@@ -1234,7 +1234,7 @@ class RealexSdkCertification extends TestCase
     public function testAuth020b()
     {
         $this->markTestSkipped('Exception not thrown');
-        
+
         $config = $this->getBaseConfig();
         ServicesContainer::configureService($config);
 
@@ -2121,7 +2121,7 @@ class RealexSdkCertification extends TestCase
         $this->assertNotNull($response);
         $this->assertEquals("00", $response->responseCode);
     }
-    
+
     /**
      * @expectedException GlobalPayments\Api\Entities\Exceptions\GatewayException
      */
@@ -2998,7 +2998,7 @@ class RealexSdkCertification extends TestCase
     public function testValidation003i()
     {
         $this->markTestSkipped('Exception not thrown');
-        
+
         $config = $this->getBaseConfig();
         $config->timeout = 20000;
         $config->channel = "ECOM";
@@ -10831,7 +10831,7 @@ class RealexSdkCertification extends TestCase
         $this->assertNotNull($response);
         $this->assertEquals("00", $response->responseCode);
     }
-    
+
     public function testCredit013b()
     {
         $config = $this->getBaseConfig();
@@ -15302,7 +15302,7 @@ class RealexSdkCertification extends TestCase
         $this->assertNotNull($response);
         $this->assertEquals("00", $response->responseCode);
     }
-    
+
     public function testManual020b()
     {
         $config = $this->getBaseConfig();
@@ -18374,9 +18374,6 @@ class RealexSdkCertification extends TestCase
         $this->assertEquals("00", $response->responseCode);
     }
 
-    /**
-     * @expectedException GlobalPayments\Api\Entities\Exceptions\GatewayException
-     */
     public function testverifyenrolled024b()
     {
         $config = $this->getBaseConfig();


### PR DESCRIPTION
This test case expects GatewayException, whereas it doesn't happen. Not sure what was the intention:
a) causing the exception with some incorrect values
or
b) the expectedException annotaton wasn't removed when copying the test case?