### PR TITLE
Update examples/manual-tokenize/charge.php

### DIFF
--- a/examples/manual-tokenize/charge.php
+++ b/examples/manual-tokenize/charge.php
@@ -3,7 +3,7 @@
 require_once ('../../vendor/autoload.php');
 
 use GlobalPayments\Api\PaymentMethods\CreditCardData;
-use GlobalPayments\Api\ServicesConfig;
+use GlobalPayments\Api\ServicesConfig\ServicesConfig;
 use GlobalPayments\Api\ServicesContainer;
 use GlobalPayments\Api\Entities\Address;
 


### PR DESCRIPTION
The namespace of ServicesConfig was not correct and didn't create the object.