### PR TITLE
PorticoConnector: import LodgingData class

### DIFF
--- a/src/Gateways/PorticoConnector.php
+++ b/src/Gateways/PorticoConnector.php
@@ -22,6 +22,7 @@ use GlobalPayments\Api\Entities\Enums\TransactionType;
 use GlobalPayments\Api\Entities\Exceptions\GatewayException;
 use GlobalPayments\Api\Entities\Exceptions\UnsupportedTransactionException;
 use GlobalPayments\Api\Entities\Reporting\CheckData;
+use GlobalPayments\Api\Entities\Reporting\LodgingData;
 use GlobalPayments\Api\PaymentMethods\ECheck;
 use GlobalPayments\Api\PaymentMethods\GiftCard;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IBalanceable;


### PR DESCRIPTION
The LodgingData class is used in PorticoConnector.php without being imported by its fully-qualified name.  This results in a class not found error when a transaction contains lodging data.

```
PHP Fatal error:  Uncaught Error: Class 'GlobalPayments\Api\Gateways\LodgingData' not found in /work/vendor/globalpayments/php-sdk/src/Gateways/PorticoConnector.php:1465
Stack trace:
#0 /work/vendor/globalpayments/php-sdk/src/Gateways/PorticoConnector.php(1190): GlobalPayments\Api\Gateways\PorticoConnector->hydrateTransactionSummary()
#1 /work/vendor/globalpayments/php-sdk/src/Gateways/PorticoConnector.php(954): GlobalPayments\Api\Gateways\PorticoConnector->mapReportResponse()
#2 /work/vendor/globalpayments/php-sdk/src/Builders/ReportBuilder.php(44): GlobalPayments\Api\Gateways\PorticoConnector->processReport()
#3 /work/list.php(14): GlobalPayments\Api\Builders\ReportBuilder->execute()
#4 {main}
  thrown in /work/vendor/globalpayments/php-sdk/src/Gateways/PorticoConnector.php on line 1465
```
