### PR TITLE
Line item total key issue resolved

### DIFF
--- a/src/Gateways/PorticoConnector.php
+++ b/src/Gateways/PorticoConnector.php
@@ -777,7 +777,7 @@ class PorticoConnector extends XmlGateway implements IPaymentGateway
                             }
 
                             if (!empty($lineItem->totalAmount)) {
-                                $linetItemNode->appendChild($xml->createElement('LineItemTotalAmt', $lineItem->totalAmount));
+                                $linetItemNode->appendChild($xml->createElement('ItemTotalAmt', $lineItem->totalAmount));
                             }
 
                             // if (!empty($lineItem->somethingsome)) {


### PR DESCRIPTION
Level 3 portico is throwing error 500 for commercialData->lineItems > *LineItemTotalAmt*
As mentioned in the below doc the *LineItemTotalAmt* key should be *ItemTotalAmt*

https://cert.api2.heartlandportico.com/Gateway/PorticoSOAPSchema/build/Default/webframe.html#Portico_xsd~c-VisaType~e-LineItems.html

https://cert.api2.heartlandportico.com/Gateway/PorticoSOAPSchema/build/Default/webframe.html#Portico_xsd~c-VisaLineItemsType~e-ItemTotalAmt.html