### PR TITLE
Allow running Credit transactions by referencing a Gateway Txn ID

### DIFF
--- a/src/Builders/AuthorizationBuilder.php
+++ b/src/Builders/AuthorizationBuilder.php
@@ -1057,7 +1057,11 @@ class AuthorizationBuilder extends TransactionBuilder
      */
     public function withTransactionId($transactionId)
     {
-        $this->paymentMethod = new TransactionReference($transactionId);
+        if ($this->paymentMethod === null)
+            $this->paymentMethod = new TransactionReference();
+
+        $this->paymentMethod->transactionId = $transactionId;
+
         return $this;
     }
 

--- a/src/Gateways/PorticoConnector.php
+++ b/src/Gateways/PorticoConnector.php
@@ -30,6 +30,7 @@ use GlobalPayments\Api\PaymentMethods\Interfaces\ICardData;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IEncryptable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IPaymentMethod;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IPinProtected;
+use GlobalPayments\Api\PaymentMethods\Interfaces\IReferencable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\ITokenizable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\ITrackData;
 use GlobalPayments\Api\PaymentMethods\RecurringPaymentMethod;
@@ -376,6 +377,9 @@ class PorticoConnector extends XmlGateway implements IPaymentGateway
         if ($builder->paymentMethod instanceof TransactionReference) {
             $block1->appendChild($xml->createElement('GatewayTxnId', $builder->paymentMethod->transactionId));
             $block1->appendChild($xml->createElement('ClientTxnId', $builder->paymentMethod->clientTransactionId));
+        }
+        else if ($builder->paymentMethod instanceof IReferencable && !empty($builder->paymentMethod->transactionId)) {
+            $block1->appendChild($xml->createElement('GatewayTxnId', $builder->paymentMethod->transactionId));
         }
 
         if ($builder->paymentMethod instanceof RecurringPaymentMethod) {

--- a/src/PaymentMethods/Credit.php
+++ b/src/PaymentMethods/Credit.php
@@ -15,18 +15,18 @@ use GlobalPayments\Api\PaymentMethods\Interfaces\IChargable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IEncryptable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IPaymentMethod;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IPrePayable;
+use GlobalPayments\Api\PaymentMethods\Interfaces\IReferencable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IRefundable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IReversable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\ISecure3d;
-use GlobalPayments\Api\PaymentMethods\Interfaces\ITokenizable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\IVerifyable;
 
 abstract class Credit implements
     IPaymentMethod,
     IEncryptable,
-    ITokenizable,
     IChargable,
     IAuthable,
+    IReferencable,
     IRefundable,
     IReversable,
     IVerifyable,

--- a/src/PaymentMethods/CreditCardData.php
+++ b/src/PaymentMethods/CreditCardData.php
@@ -7,12 +7,13 @@ use GlobalPayments\Api\Builders\ManagementBuilder;
 use GlobalPayments\Api\Entities\Enums\CvnPresenceIndicator;
 use GlobalPayments\Api\Entities\Enums\TransactionType;
 use GlobalPayments\Api\PaymentMethods\Interfaces\ICardData;
+use GlobalPayments\Api\PaymentMethods\Interfaces\ITokenizable;
 use GlobalPayments\Api\Entities\Enums\DccProcessor;
 use GlobalPayments\Api\Entities\Enums\DccRateType;
 use GlobalPayments\Api\Entities\DccRateData;
 use GlobalPayments\Api\Entities\ThreeDSecure;
 
-class CreditCardData extends Credit implements ICardData
+class CreditCardData extends Credit implements ITokenizable, ICardData
 {
     /**
      * Card number

--- a/src/PaymentMethods/CreditCardReference.php
+++ b/src/PaymentMethods/CreditCardReference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GlobalPayments\Api\PaymentMethods;
+
+use GlobalPayments\Api\Builders\AuthorizationBuilder;
+use GlobalPayments\Api\Builders\ManagementBuilder;
+use GlobalPayments\Api\Entities\Enums\CvnPresenceIndicator;
+use GlobalPayments\Api\Entities\Enums\TransactionType;
+use GlobalPayments\Api\Entities\Enums\DccProcessor;
+use GlobalPayments\Api\Entities\Enums\DccRateType;
+use GlobalPayments\Api\Entities\DccRateData;
+use GlobalPayments\Api\Entities\ThreeDSecure;
+
+class CreditCardReference extends Credit
+{
+}

--- a/src/PaymentMethods/CreditTrackData.php
+++ b/src/PaymentMethods/CreditTrackData.php
@@ -2,10 +2,11 @@
 
 namespace GlobalPayments\Api\PaymentMethods;
 
+use GlobalPayments\Api\PaymentMethods\Interfaces\ITokenizable;
 use GlobalPayments\Api\PaymentMethods\Interfaces\ITrackData;
 use GlobalPayments\Api\Utils\CardUtils;
 
-class CreditTrackData extends Credit implements ITrackData
+class CreditTrackData extends Credit implements ITokenizable, ITrackData
 {
     public $entryMethod;
     public $value;

--- a/src/PaymentMethods/Interfaces/IReferencable.php
+++ b/src/PaymentMethods/Interfaces/IReferencable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GlobalPayments\Api\PaymentMethods\Interfaces;
+
+interface IReferencable
+{
+}


### PR DESCRIPTION
I submitted a project for certification by Heartland only to have it rejected because the Refund test case did not reference the original transaction.  As the SDK did not allow these reference transactions, this patch adds support for it.

Although no additional data is required beyond the transactionId, the PaymentMethods/Credit class is protected so we needed to either remove the 'protected' keyword or create a new (empty) sub-class; I went with the latter and created PaymentMethods/CreditCardReference.

ITokenizable needed to be removed from PaymentMethods/Credit as otherwise Portico rejected the transaction due to `<CardData><TokenRequest>N</TokenRequest></CardData>` not being allowed when running transactions by the Gateway Txn ID without card data.  ITokenizable was then added to PaymentMethods/CreditCardData and PaymentMethods/CreditTrackData so it's still sent when card data is present.

A new interface IReferencable was then created so we don't send `<GatewayTxnId>` with every transaction.

The withTransactionId() function in Builders/AuthorizationBuilder not only did not set $transactionId correctly, it also clobbered paymentMethod.  This has been fixed.

To use, first either set `$card = new CreditCardReference();` if you only have the Gateway Txn ID, or set `$card = new CreditCardData();` and fill out the card data if you want to also pass the card number to the gateway.  Then just 
`->withTransactionId( $gatewayTxnId )`.  Test case example:
```
    public function test034bCreditReturnByRef()
    {
        //$card = TestCards::masterCardManual();
        /* or */
        $card = new CreditCardReference();                                                                                                                                                            
        $response = $card->refund(15.15)
              ->withTransactionId( self::$gatewayTxnId )
	      ->withCurrency('USD')
              ->withInvoiceNumber('123456')
              ->withEcommerceInfo($this->ecommerceInfo)
              ->execute();

        $this->assertEquals(true, $response != null);
	$this->assertEquals('00', $response->responseCode);

    }
```