### PR TITLE
GpEcomConfig as acceptable class

### DIFF
--- a/src/Services/HostedService.php
+++ b/src/Services/HostedService.php
@@ -7,6 +7,7 @@ use GlobalPayments\Api\Builders\ManagementBuilder;
 use GlobalPayments\Api\Entities\Enums\PaymentMethodType;
 use GlobalPayments\Api\Entities\Enums\TransactionType;
 use GlobalPayments\Api\PaymentMethods\TransactionReference;
+use GlobalPayments\Api\ServiceConfigs\Gateways\GpEcomConfig;
 use GlobalPayments\Api\ServicesContainer;
 use GlobalPayments\Api\Utils\GenerationUtils;
 use GlobalPayments\Api\Entities\Exceptions\ApiException;
@@ -26,7 +27,7 @@ class HostedService
     /**
      * Instatiates a new object
      *
-     * @param ServicesConfig $config Service config
+     * @param ServicesConfig|GpEcomConfig $config Service/Ecom config
      *
      * @return void
      */


### PR DESCRIPTION
From documentation here https://developer.globalpay.com/ecommerce/hosted-solution/HPP-Guide#hpp and implementation, the HostedService constructor should accept the GpEcomConfig class as a service config