### PR TITLE
Add intl as a required extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "ext-dom": "*",
     "ext-openssl": "*",
     "ext-json": "*",
-    "ext-zlib": "*"
+    "ext-zlib": "*",
+    "ext-intl": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
The StringUtils class uses the intl extension's Locale class https://github.com/globalpayments/php-sdk/blob/master/src/Utils/StringUtils.php#L7