### PR TITLE
Unpin symfony/process version constraint to allow newer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "ext-intl": "*",
     "ext-mbstring": "*",
     "ext-fileinfo": "*",
-    "symfony/process": "7.1.8"
+    "symfony/process": "^7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5 || ^8.5 || ~9.4",


### PR DESCRIPTION
Changed from fixed version 7.1.8 to ^7.1 constraint to allow compatibility with projects using newer Symfony 7.x versions while maintaining minimum version requirement.