### PR TITLE
Avoid undefined array key warnings when parsing HPP responses without uppercase keys

### DIFF
--- a/src/Services/HostedService.php
+++ b/src/Services/HostedService.php
@@ -141,12 +141,12 @@ class HostedService
             $response = $this->mapTransactionStatusResponse($response);
         }
 
-        $timestamp = $response["TIMESTAMP"];
-        $merchantId = $response["MERCHANT_ID"];
-        $orderId = $response["ORDER_ID"];
-        $result = $response["RESULT"];
-        $message = $response["MESSAGE"];
-        $transactionId = $response["PASREF"];
+        $timestamp = $response["TIMESTAMP"] ?? "";
+        $merchantId = $response["MERCHANT_ID"] ?? "";
+        $orderId = $response["ORDER_ID"] ?? "";
+        $result = $response["RESULT"] ?? "";
+        $message = $response["MESSAGE"] ?? "";
+        $transactionId = $response["PASREF"] ?? "";
         $authCode = $response["AUTHCODE"] ?? "";
         $paymentMethod = $response["PAYMENTMETHOD"] ?? "";
 

--- a/test/Integration/Gateways/GpEcomConnector/HppTest.php
+++ b/test/Integration/Gateways/GpEcomConnector/HppTest.php
@@ -1099,6 +1099,30 @@ class HppTest extends TestCase
         $this->assertEquals("00", $responseCode);
     }
 
+    public function testParseResponseWithoutUppercaseKeysDoesNotWarn()
+    {
+        $service = new HostedService($this->config());
+
+        $response = [];
+        $response["SHA1HASH"] = GenerationUtils::generateNewHash(
+            "secret",
+            implode('.', ["", "", "", "", "", "", ""]),
+            ShaHashType::SHA1
+        );
+
+        set_error_handler(function ($errno, $errstr) {
+            throw new \ErrorException($errstr);
+        });
+        try {
+            $parsedResponse = $service->parseResponse(json_encode($response));
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($parsedResponse);
+        $this->assertEquals("", $parsedResponse->responseCode);
+    }
+
     /* 06. CardStorageCreatePayerStoreCardResponse */
 
     public function testCardStorageCreatePayerStoreCardResponse()


### PR DESCRIPTION
Fixes #139. `HostedService::parseResponse()` reads `TIMESTAMP`, `MERCHANT_ID`, `ORDER_ID`, `RESULT`, `MESSAGE` and `PASREF` with bare array access, so on PHP 8+ a response that does not contain those uppercase keys (for example a lightbox HPP response that only goes through the non-`fundsstatus` branch) emits one "Undefined array key" warning per field before the hash is even checked. This guards those reads with `?? ""`, matching the `AUTHCODE`/`PAYMENTMETHOD` lines just below them, and adds a parseResponse test that fails with the old code and passes with the guard.